### PR TITLE
feat: document sharing permission & password APIs, publishFile method

### DIFF
--- a/src/Lark.ts
+++ b/src/Lark.ts
@@ -9,6 +9,7 @@ import {
     DocumentAIModel,
     DocumentModel,
     DriveFileModel,
+    DriveFileType,
     TableFormView,
     UserIdType,
     WikiNode,
@@ -289,6 +290,25 @@ export class LarkApp implements LarkAppOption {
         const doc_token = type === 'wiki' ? (await this.wiki2drive(id)).obj_token : id;
 
         return this.documentStore.getOneContent(doc_token, 'markdown');
+    }
+
+    /**
+     * @see {@link DriveFileModel#updatePermission}
+     * @see {@link DriveFileModel#enablePassword}
+     */
+    async publishFile(URI: string, enablePassword = false, editable = false) {
+        await this.getAccessToken();
+
+        let [[type, token]] = DriveFileModel.parseURI(URI);
+
+        if (type === 'wiki') ({ obj_type: type, obj_token: token } = await this.wiki2drive(token));
+        else type = getLarkDocumentType(type as LarkDocumentPathType);
+
+        await this.driveFileStore.updatePermission(token, type as DriveFileType, {
+            external_access_entity: 'open',
+            link_share_entity: editable ? 'tenant_editable' : 'tenant_readable'
+        });
+        if (enablePassword) await this.driveFileStore.enablePassword(token, type as DriveFileType);
     }
 
     async getBiTableSchema(appId: string): Promise<BiTableSchema> {

--- a/src/module/Drive/index.ts
+++ b/src/module/Drive/index.ts
@@ -4,7 +4,15 @@ import { buildURLData, splitArray } from 'web-utility';
 
 import { LarkData, LarkDocumentPathTypeMap, LarkDocumentType, UploadTargetType } from '../../type';
 import { UserIdType } from '../User/type';
-import { CopiedFile, DriveFile, DriveFileType, TransferOwner, TransferOption } from './type';
+import {
+    CopiedFile,
+    DriveFile,
+    DriveFileType,
+    PasswordResponse,
+    PublicPermission,
+    TransferOwner,
+    TransferOption
+} from './type';
 
 export * from './type';
 
@@ -120,5 +128,28 @@ export abstract class DriveFileModel extends BaseListModel<DriveFile> {
             `${this.baseURI}/permissions/${token}/members/transfer_owner?${buildURLData({ ...option, type })}`,
             newOwner
         );
+    }
+
+    /**
+     * @see {@link https://open.feishu.cn/document/server-docs/docs/permission/permission-public/patch-2}
+     */
+    @toggle('uploading')
+    async updatePermission(token: string, type: DriveFileType, permission: PublicPermission) {
+        const { body } = await this.client.patch<LarkData>(
+            `drive/v2/permissions/${token}/public?${buildURLData({ type })}`,
+            permission
+        );
+        return body!.data;
+    }
+
+    /**
+     * @see {@link https://open.feishu.cn/document/server-docs/docs/permission/permission-public/permission-public-password/create}
+     */
+    @toggle('uploading')
+    async enablePassword(token: string, type: DriveFileType) {
+        const { body } = await this.client.post<LarkData<PasswordResponse>>(
+            `drive/v1/permissions/${token}/public/password?${buildURLData({ type })}`
+        );
+        return body!.data!.password;
     }
 }

--- a/src/module/Drive/type.ts
+++ b/src/module/Drive/type.ts
@@ -26,3 +26,31 @@ export interface TransferOption {
     stay_put?: boolean;
     old_owner_perm?: 'view' | 'edit' | 'full_access';
 }
+
+export type ExternalAccessEntity = 'open' | 'closed' | 'allow_share_partner_tenant';
+
+export type SecurityEntity = 'anyone_can_view' | 'anyone_can_edit' | 'only_full_access';
+
+export type CommentEntity = 'anyone_can_view' | 'anyone_can_edit';
+
+export type ShareEntity = 'anyone' | 'same_tenant';
+
+export type ManageCollaboratorEntity =
+    | 'collaborator_can_view'
+    | 'collaborator_can_edit'
+    | 'collaborator_full_access';
+
+export type LinkShareEntity = 'tenant_readable' | 'tenant_editable' | 'partner_tenant_readable';
+
+export interface PublicPermission {
+    external_access_entity?: ExternalAccessEntity;
+    security_entity?: SecurityEntity;
+    comment_entity?: CommentEntity;
+    share_entity?: ShareEntity;
+    manage_collaborator_entity?: ManageCollaboratorEntity;
+    link_share_entity?: LinkShareEntity;
+}
+
+export interface PasswordResponse {
+    password: string;
+}


### PR DESCRIPTION
[![PR-38](https://badgen.net/badge/GitHub.dev/PR-38/blue?icon=visualstudio)](https://github.dev/idea2app/MobX-Lark/pull/38) [![PR-38](https://badgen.net/badge/GitHub%20codespaces/PR-38/black?icon=github)](https://codespaces.new/idea2app/MobX-Lark/pull/38) [![PR-38](https://badgen.net/badge/GitPod.io/PR-38/orange?icon=git)](https://gitpod.io/?autostart=true#https://github.com/idea2app/MobX-Lark/pull/38) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=idea2app&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

## Changes

### New DriveFileModel methods:
1. **`updatePermission(token, type, permission)`** - Update document common/public sharing settings
2. **`enablePassword(token, type)`** - Enable password protection for a document
3. **`publishFile(URI, enablePassword, editable)`** - One-call method to publish a file with sharing options

### New types (in `Drive/type.ts`):
- `PublicPermission` - Permission settings interface
- `PasswordResponse` - Password response type
- Supporting enums: `ExternalAccessEntity`, `SecurityEntity`, `CommentEntity`, `ShareEntity`, `ManageCollaboratorEntity`, `LinkShareEntity`

### API references:
- [Update common settings](https://open.feishu.cn/document/server-docs/docs/permission/permission-public/patch-2)
- [Enable password](https://open.feishu.cn/document/server-docs/docs/permission/permission-public/permission-public-password/create)

Closes #35 